### PR TITLE
Allow use of urllib3 v2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup_args = dict(
 install_requires = [
     'aiohttp>3.6.2,<4.0.0',
     'requests>=2.24.0,<3.0.0',
-    'urllib3<2',
+    'urllib3>=1.26,<3',
 ]
 
 setup(

--- a/ujenkins/adapters/sync.py
+++ b/ujenkins/adapters/sync.py
@@ -112,7 +112,7 @@ class JenkinsClient(Jenkins):
             total=retry['total'],
             backoff_factor=retry.get('factor', 1),
             status_forcelist=retry.get('statuses', []),
-            method_whitelist=retry.get('methods', [
+            allowed_methods=retry.get('methods', [
                 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE'
             ]),
         ))


### PR DESCRIPTION
Per the [urllib3 v2 migration guide](https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html), this should allow use of `urllib3` v2.x rather than having to pin to older versions (which may impact other code deps as it did with some of mine 🙂 )

Code passes all `tox` checks with this change