### PR TITLE
Builds.get() new arg: fields

### DIFF
--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -68,7 +68,7 @@ params = [
             'idx': 4,
             'url': 'https://localhost:8080/job/dev/job/testgene/2/',
             'number': 2,
-            'request_url': 'http://server//job/job/api/json?tree=allBuilds%5Bnumber,url%5D',
+            'request_url': '//job/job/api/json?tree=allBuilds%5Bnumber,url%5D',
         },
     ),
     (
@@ -78,10 +78,6 @@ params = [
         {},
         filter_builds_response(fields=['number'], start=1, end=5),
         {
-            'length': 5,
-            'idx': 4,
-            'number': 2,
-            'request_url': 'http://server//job/job/api/json?tree=allBuilds%5Bnumber%5D',
             'error': TypeError
         }
     ),
@@ -94,7 +90,7 @@ params = [
             'idx': 1,
             'number': 3,
             'request_url':
-                'http://server//job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B3,%7D'
+                '//job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B3,%7D'
         }
     ),
     (
@@ -106,7 +102,7 @@ params = [
             'idx': 2,
             'number': 1,
             'request_url':
-                'http://server//job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B,2%7D'
+                '//job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B,2%7D'
         }
     )
 ]
@@ -125,7 +121,7 @@ def test_get(client, args, kwargs, mock_body, expectations):
             client.builds.get('job', *args, **kwargs)
     else:
         response = client.builds.get('job', *args, **kwargs)
-        request_url = responses.calls[0].request.url
+        request_url = responses.calls[0].request.url.replace(client.host, '')
 
         assert len(response) == expectations['length']
         assert response[expectations['idx']-1]['number'] == expectations['number']

--- a/tests/test_builds_response.py
+++ b/tests/test_builds_response.py
@@ -232,12 +232,14 @@ def filter_builds_response(fields=None, start=None, end=None):
     Args:
     - data (list of dict):
         The list containing Jenkins build data.
+
     - fields (list of str, optional):
         The fields you want to retain. If None, or contains '*', all fields are retained
 
 
     Returns:
-    - list of dict: Filtered Jenkins build data.
+    - JSON (str):
+         Filtered Jenkins build data in JSON format.
     """
 
     # Filter by range if start and end are provided

--- a/ujenkins/endpoints/builds.py
+++ b/ujenkins/endpoints/builds.py
@@ -75,11 +75,13 @@ class Builds:
                 Possible values are mentioned in the available fields.
                 If empty, default fields will be returned.
 
-            start (Optional[int]): The start index of the builds to retrieve.
+            start (Optional[int]):
+                The start index of the builds to retrieve.
                 Used with the 'end' parameter to specify a range.
                 Defaults to None.
 
-            end (Optional[int]): The end index of the builds to retrieve.
+            end (Optional[int]):
+                The end index of the builds to retrieve.
                 Used with the 'start' parameter to specify a range.
                 Defaults to None.
 


### PR DESCRIPTION
I have a use case where I want to be able to see all running builds without having to iterate over by item.
Seeing the duration and status is also useful.

There are other useful fields as well which I've included in the docstring. 

I didn't run the tests. Sorry.

