### PR TITLE
Added url path amendment logic for corner cases with two leading slashes

### DIFF
--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -68,7 +68,7 @@ params = [
             'idx': 4,
             'url': 'https://localhost:8080/job/dev/job/testgene/2/',
             'number': 2,
-            'request_url': '//job/job/api/json?tree=allBuilds%5Bnumber,url%5D',
+            'request_url': '/job/job/api/json?tree=allBuilds%5Bnumber,url%5D',
         },
     ),
     (
@@ -90,7 +90,7 @@ params = [
             'idx': 1,
             'number': 3,
             'request_url':
-                '//job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B3,%7D'
+                '/job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B3,%7D'
         }
     ),
     (
@@ -102,7 +102,7 @@ params = [
             'idx': 2,
             'number': 1,
             'request_url':
-                '//job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B,2%7D'
+                '/job/job/api/json?tree=allBuilds%5Bnumber,url,timestamp%5D%7B,2%7D'
         }
     )
 ]
@@ -197,7 +197,7 @@ def test_get_list_artifacts(client):
     assert len(artifacts) == 1
     assert artifacts[0]['name'] == 'photo.jpg'
     assert artifacts[0]['path'] == 'photo.jpg'
-    assert artifacts[0]['url'] == 'http://server//job/jobbb/14/artifact/photo.jpg'
+    assert artifacts[0]['url'] == 'http://server/job/jobbb/14/artifact/photo.jpg'
 
 
 @responses.activate

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ from ujenkins.helpers import (
     construct_job_config,
     construct_node_config,
     parse_build_url,
-    fix_path,
+    normalize_url,
 )
 
 
@@ -46,10 +46,10 @@ def test_parse_build_urlt():
         parse_build_url('xxx')
 
 
-def test_fix_path():
+def test_normalize_url():
     # double slashes appear if folder name is empty
     invalid_path = '//job/job_name/enable'
-    assert fix_path(invalid_path) == '/job/job_name/enable'
+    assert normalize_url(invalid_path) == '/job/job_name/enable'
 
     valid_path = '/folder_name/job/job_name/enable'
-    assert fix_path(valid_path) == '/folder_name/job/job_name/enable'
+    assert normalize_url(valid_path) == '/folder_name/job/job_name/enable'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,7 @@ from ujenkins.helpers import (
     construct_job_config,
     construct_node_config,
     parse_build_url,
+    fix_path,
 )
 
 
@@ -43,3 +44,12 @@ def test_parse_build_urlt():
 
     with pytest.raises(JenkinsError):
         parse_build_url('xxx')
+
+
+def test_fix_path():
+    # double slashes appear if folder name is empty
+    invalid_path = '//job/job_name/enable'
+    assert fix_path(invalid_path) == '/job/job_name/enable'
+
+    valid_path = '/folder_name/job/job_name/enable'
+    assert fix_path(valid_path) == '/folder_name/job/job_name/enable'

--- a/ujenkins/endpoints/builds.py
+++ b/ujenkins/endpoints/builds.py
@@ -104,7 +104,10 @@ class Builds:
         fields_str = ','.join(fields) if fields else 'number,url'
         return self.jenkins._request(
             'GET',
-            normalize_url(f'/{folder_name}/job/{job_name}/api/json?tree=allBuilds[{fields_str}]{pagination}'),
+            normalize_url(
+                f'/{folder_name}/job/{job_name}/api/'
+                f'json?tree=allBuilds[{fields_str}]{pagination}'
+            ),
             _callback=callback,
         )
 

--- a/ujenkins/endpoints/builds.py
+++ b/ujenkins/endpoints/builds.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any, List, Optional, Union
 
 from ujenkins.exceptions import JenkinsError
+from ujenkins.helpers import normalize_url
 
 
 class Builds:
@@ -103,7 +104,7 @@ class Builds:
         fields_str = ','.join(fields) if fields else 'number,url'
         return self.jenkins._request(
             'GET',
-            f'/{folder_name}/job/{job_name}/api/json?tree=allBuilds[{fields_str}]{pagination}',
+            normalize_url(f'/{folder_name}/job/{job_name}/api/json?tree=allBuilds[{fields_str}]{pagination}'),
             _callback=callback,
         )
 
@@ -125,7 +126,7 @@ class Builds:
 
         return self.jenkins._request(
             'GET',
-            f'/{folder_name}/job/{job_name}/{build_id}/api/json'
+            normalize_url(f'/{folder_name}/job/{job_name}/{build_id}/api/json')
         )
 
     def get_output(self, name: str, build_id: Union[int, str]) -> str:
@@ -146,7 +147,7 @@ class Builds:
 
         return self.jenkins._request(
             'GET',
-            f'/{folder_name}/job/{job_name}/{build_id}/consoleText',
+            normalize_url(f'/{folder_name}/job/{job_name}/{build_id}/consoleText'),
             _callback=self.jenkins._return_text,
         )
 
@@ -175,7 +176,7 @@ class Builds:
 
         return self.jenkins._request(
             'GET',
-            f'/{folder_name}/job/{job_name}/{build_id}/artifact/{path}',
+            normalize_url(f'/{folder_name}/job/{job_name}/{build_id}/artifact/{path}'),
             _raw_content=True,
             _callback=callback,
         )
@@ -228,7 +229,7 @@ class Builds:
 
         root_url = (
             self.jenkins.host +
-            f'/{folder_name}/job/{job_name}/{build_id}/artifact/'
+            normalize_url(f'/{folder_name}/job/{job_name}/{build_id}/artifact/')
         )
 
         return self.jenkins._chain([callback1, callback2])
@@ -312,7 +313,7 @@ class Builds:
             return data
 
         folder_name, job_name = self.jenkins._get_folder_and_job_name(name)
-        path = f'/{folder_name}/job/{job_name}'
+        path = normalize_url(f'/{folder_name}/job/{job_name}')
 
         data = format_data(parameters, kwargs)
         if data:
@@ -346,7 +347,7 @@ class Builds:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/{build_id}/stop'
+            normalize_url(f'/{folder_name}/job/{job_name}/{build_id}/stop')
         )
 
     def delete(self, name: str, build_id: Union[int, str]) -> None:
@@ -367,5 +368,5 @@ class Builds:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/{build_id}/doDelete'
+            normalize_url(f'/{folder_name}/job/{job_name}/{build_id}/doDelete')
         )

--- a/ujenkins/endpoints/jobs.py
+++ b/ujenkins/endpoints/jobs.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import Any, Dict, Optional
 
 from ujenkins.exceptions import JenkinsNotFoundError
-from ujenkins.helpers import fix_path
+from ujenkins.helpers import normalize_url
 
 
 class Jobs:
@@ -75,7 +75,7 @@ class Jobs:
 
         return self.jenkins._request(
             'GET',
-            fix_path(f'/{folder_name}/job/{job_name}/api/json')
+            normalize_url(f'/{folder_name}/job/{job_name}/api/json')
         )
 
     def get_config(self, name: str) -> str:
@@ -93,7 +93,7 @@ class Jobs:
 
         return self.jenkins._request(
             'GET',
-            fix_path(f'/{folder_name}/job/{job_name}/config.xml'),
+            normalize_url(f'/{folder_name}/job/{job_name}/config.xml'),
             _callback=self.jenkins._return_text,
         )
 
@@ -145,7 +145,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/createItem'),
+            normalize_url(f'/{folder_name}/createItem'),
             params=params,
             data=config,
             headers=headers
@@ -171,7 +171,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/job/{job_name}/config.xml'),
+            normalize_url(f'/{folder_name}/job/{job_name}/config.xml'),
             data=config,
             headers={'Content-Type': 'text/xml'},
         )
@@ -191,7 +191,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/job/{job_name}/doDelete')
+            normalize_url(f'/{folder_name}/job/{job_name}/doDelete')
         )
 
     def copy(self, name: str, new_name: str) -> None:
@@ -218,7 +218,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/createItem'),
+            normalize_url(f'/{folder_name}/createItem'),
             params=params
         )
 
@@ -244,7 +244,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/job/{job_name}/doRename'),
+            normalize_url(f'/{folder_name}/job/{job_name}/doRename'),
             params=params
         )
 
@@ -263,7 +263,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/job/{job_name}/enable')
+            normalize_url(f'/{folder_name}/job/{job_name}/enable')
         )
 
     def disable(self, name: str) -> None:
@@ -281,5 +281,5 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            fix_path(f'/{folder_name}/job/{job_name}/disable')
+            normalize_url(f'/{folder_name}/job/{job_name}/disable')
         )

--- a/ujenkins/endpoints/jobs.py
+++ b/ujenkins/endpoints/jobs.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any, Dict, Optional
 
 from ujenkins.exceptions import JenkinsNotFoundError
+from ujenkins.helpers import fix_path
 
 
 class Jobs:
@@ -74,7 +75,7 @@ class Jobs:
 
         return self.jenkins._request(
             'GET',
-            f'/{folder_name}/job/{job_name}/api/json'
+            fix_path(f'/{folder_name}/job/{job_name}/api/json')
         )
 
     def get_config(self, name: str) -> str:
@@ -92,7 +93,7 @@ class Jobs:
 
         return self.jenkins._request(
             'GET',
-            f'/{folder_name}/job/{job_name}/config.xml',
+            fix_path(f'/{folder_name}/job/{job_name}/config.xml'),
             _callback=self.jenkins._return_text,
         )
 
@@ -144,7 +145,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/createItem',
+            fix_path(f'/{folder_name}/createItem'),
             params=params,
             data=config,
             headers=headers
@@ -170,7 +171,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/config.xml',
+            fix_path(f'/{folder_name}/job/{job_name}/config.xml'),
             data=config,
             headers={'Content-Type': 'text/xml'},
         )
@@ -190,7 +191,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/doDelete'
+            fix_path(f'/{folder_name}/job/{job_name}/doDelete')
         )
 
     def copy(self, name: str, new_name: str) -> None:
@@ -217,7 +218,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/createItem',
+            fix_path(f'/{folder_name}/createItem'),
             params=params
         )
 
@@ -243,7 +244,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/doRename',
+            fix_path(f'/{folder_name}/job/{job_name}/doRename'),
             params=params
         )
 
@@ -262,7 +263,7 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/enable'
+            fix_path(f'/{folder_name}/job/{job_name}/enable')
         )
 
     def disable(self, name: str) -> None:
@@ -280,5 +281,5 @@ class Jobs:
 
         return self.jenkins._request(
             'POST',
-            f'/{folder_name}/job/{job_name}/disable'
+            fix_path(f'/{folder_name}/job/{job_name}/disable')
         )

--- a/ujenkins/helpers.py
+++ b/ujenkins/helpers.py
@@ -161,3 +161,19 @@ def parse_build_url(build_url: str) -> Tuple[str, int]:
     ))
 
     return name, int(match.group('build_number'))
+
+
+def fix_path(path: str) -> str:
+    """
+    Amend job path in case it starts from two forward slashes.
+
+    Args:
+        path (str):
+            Path to amend, e.g. //job/some_job/enable
+
+    Returns:
+        str: amended path, e.g.: /job/some_job/enable
+    """
+    if path.startswith('//'):
+        return path[1:]
+    return path

--- a/ujenkins/helpers.py
+++ b/ujenkins/helpers.py
@@ -163,7 +163,7 @@ def parse_build_url(build_url: str) -> Tuple[str, int]:
     return name, int(match.group('build_number'))
 
 
-def fix_path(path: str) -> str:
+def normalize_url(path: str) -> str:
     """
     Amend job path in case it starts from two forward slashes.
 


### PR DESCRIPTION
After migrating to Jenkins 2.492.1 and switching from HTTP to HTTPS, I started encountering the following error related to name resolution:
    raise ClientConnectorError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host job:443 ssl:True [getaddrinfo failed]

Having dug into the library, it appeared that in some cases while processing the job's relative path, there is no 'folder_name'. In such cases, using the format `f'/{folder_name}/job/{job_name}/enable'` results in a double leading slash like this: `f'//job/{job_name}/enable'`. Consequently, this causes a downstream library to incorrectly determine the host as 'job' instead of 'jenkins.my.domain', as it seems to simply take the part after the two forward slashes, e.g., after 'https://'.

It appeared to be an incorrect side effect, so I implemented a fix that resolved my issue.